### PR TITLE
Fix "Code not found" message typo

### DIFF
--- a/InventoryManager/Helpers/TypeConverter.cs
+++ b/InventoryManager/Helpers/TypeConverter.cs
@@ -88,7 +88,7 @@ namespace InventoryManager.Helpers
         {
             var readResult = databaseController.TryReadEntityByCode<T>(input, out convertedValue);
             if (!readResult.IsSuccess)
-                return new Result() { IsSuccess = false, ErrorDescription = $"Сode not found: {input}" };
+                return new Result() { IsSuccess = false, ErrorDescription = $"Code not found: {input}" };
 
             return new Result() { IsSuccess = true };
         }


### PR DESCRIPTION
Replace cyrillic С with latin C in "Code"